### PR TITLE
Refactor hooks and utilities

### DIFF
--- a/src/context/StompContext.tsx
+++ b/src/context/StompContext.tsx
@@ -2,7 +2,7 @@
 import React, { createContext, useContext, ReactNode } from 'react';
 import { useStompClient, UseStompClientOptions, UseStompClientReturn } from '../hooks/useStompClient';
 
-const StompContext = createContext<UseStompClientReturn | null>(null);
+export const StompContext = createContext<UseStompClientReturn | null>(null);
 
 interface StompProviderProps {
   children: ReactNode;

--- a/src/hooks/useStompClient.ts
+++ b/src/hooks/useStompClient.ts
@@ -23,7 +23,7 @@ export function useStompClient(config: UseStompClientConfig) {
     const [connected, setConnected] = useState(false);
     const activeSubscriptions = useRef<Record<string, StompSubscription & { callback: (data: any) => void }>>({});
     const retryAttempts = useRef(0);
-    const messageQueue: any[] = [];
+    const messageQueue = useRef<any[]>([]);
     const maxRetry = config.maxRetryAttempts ?? 5;
 
     const resolveTopic = (t: string) => config.namespace ? `/${config.namespace}/${t}` : `/${t}`;
@@ -123,15 +123,17 @@ export function useStompClient(config: UseStompClientConfig) {
             client.current.publish({destination: fullDest, body: JSON.stringify(processed), headers});
         } else {
             storeOfflineMessage({destination: fullDest, body: JSON.stringify(processed), headers});
-            messageQueue.push({destination: fullDest, body: JSON.stringify(processed), headers});
+            messageQueue.current.push({destination: fullDest, body: JSON.stringify(processed), headers});
         }
     };
 
     useEffect(() => {
         if (connected) {
-            while (messageQueue.length > 0) {
-                const msg = messageQueue.shift();
-                client.current?.publish(msg);
+            while (messageQueue.current.length > 0) {
+                const msg = messageQueue.current.shift();
+                if (msg) {
+                    client.current?.publish(msg);
+                }
             }
         }
     }, [connected]);

--- a/src/hooks/useStompTopics.ts
+++ b/src/hooks/useStompTopics.ts
@@ -1,8 +1,8 @@
 import { useEffect, useState } from 'react';
-import { useStompClient } from './useStompClient';
+import { useStomp } from '../context/StompContext';
 
 export function useStompTopics<T extends Record<string, any>>(topics: string[]) {
-  const { subscribeTyped } = useStompClient({ brokerURL: '', namespace: 'app' });
+  const { subscribeTyped } = useStomp();
   const [messages, setMessages] = useState<Partial<T>>({});
 
   useEffect(() => {

--- a/src/mocks/MockStompProvider.tsx
+++ b/src/mocks/MockStompProvider.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { StompContext } from '../context/StompContext';
 
 export const MockStompProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const mockClient = {
@@ -12,7 +13,9 @@ export const MockStompProvider: React.FC<{ children: React.ReactNode }> = ({ chi
     connected: true,
     subscribeTyped: () => {},
     send: () => {},
-  };
+    reconnect: () => {},
+    subscribe: () => ({ unsubscribe: () => {} }),
+  } as any;
 
-  return <>{children}</>;
+  return <StompContext.Provider value={context}>{children}</StompContext.Provider>;
 };

--- a/src/utils/adaptiveThrottle.ts
+++ b/src/utils/adaptiveThrottle.ts
@@ -2,7 +2,10 @@ let lastProcess = 0;
 let throttleInterval = 100; // start 100ms
 export function adaptiveThrottle() {
   const now = Date.now();
-  const connection = (navigator as any).connection;
+  const connection =
+    typeof navigator !== 'undefined' && (navigator as any).connection
+      ? (navigator as any).connection
+      : null;
   if (connection) {
     if (connection.downlink < 1) throttleInterval = 500;
     else if (connection.downlink < 3) throttleInterval = 250;

--- a/src/utils/monitoring.ts
+++ b/src/utils/monitoring.ts
@@ -9,12 +9,18 @@ const metrics = {
 eventBus.on('error', () => metrics.errors++);
 eventBus.on('connected', () => metrics.retries++);
 
-export const startMonitoring = () => {
-  setInterval(() => {
-    fetch('/api/metrics', {
+export interface MonitoringOptions {
+  endpoint?: string;
+  interval?: number;
+}
+
+export const startMonitoring = (options: MonitoringOptions = {}) => {
+  const { endpoint = '/api/metrics', interval = 15000 } = options;
+  return setInterval(() => {
+    fetch(endpoint, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(metrics),
     });
-  }, 15000);
+  }, interval);
 };


### PR DESCRIPTION
## Summary
- use the global STOMP context in `useStompTopics`
- persist the message queue with a ref in `useStompClient`
- export the context and wrap children in `MockStompProvider`
- add configuration options for monitoring
- guard `navigator.connection` access in adaptive throttle

## Testing
- `npm run build` *(fails: Cannot find module 'react' or its type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6880fdf59a1083259c2751a085938069